### PR TITLE
fix h01: address issue in recoverErc20 function

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -130,6 +130,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      */
     function recoverErc20(address tokenAddress, uint256 amount) external {
         require(stakingTokens[tokenAddress].lastUpdateTime == 0, "Can't recover staking token");
+        require(tokenAddress != address(rewardToken), "Can't recover reward token");
         IERC20(tokenAddress).safeTransfer(owner(), amount);
 
         emit RecoverErc20(tokenAddress, owner(), amount);

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -1,8 +1,8 @@
 import { expect, ethers, Contract, SignerWithAddress, toWei, toBN } from "./utils";
-import { acceleratingDistributorFixture } from "./AcceleratingDistributor.Fixture";
+import { acceleratingDistributorFixture, enableTokenForStaking } from "./AcceleratingDistributor.Fixture";
 import { baseEmissionRate, maxMultiplier, secondsToMaxMultiplier } from "./constants";
 
-let timer: Contract, acrossToken: Contract, distributor: Contract, lpToken1: Contract, lpToken2: Contract;
+let timer: Contract, acrossToken: Contract, distributor: Contract, lpToken1: Contract;
 let owner: SignerWithAddress, rando: SignerWithAddress;
 
 describe("AcceleratingDistributor: Admin Functions", async function () {
@@ -31,11 +31,16 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
   });
 
   it("Can not recover staking tokens", async function () {
-    // Should not be able to recover staking tokens.
     await distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier);
     await lpToken1.mint(distributor.address, toWei(420));
     await expect(distributor.recoverErc20(lpToken1.address, toWei(420))).to.be.revertedWith(
       "Can't recover staking token"
+    );
+  });
+  it("Can not recover reward token", async function () {
+    await enableTokenForStaking(distributor, lpToken1, acrossToken);
+    await expect(distributor.recoverErc20(acrossToken.address, toWei(420))).to.be.revertedWith(
+      "Can't recover reward token"
     );
   });
 

--- a/test/AcceleratingDistributor.Events.ts
+++ b/test/AcceleratingDistributor.Events.ts
@@ -1,4 +1,5 @@
-import { expect, ethers, Contract, SignerWithAddress, toWei, advanceTime, seedAndApproveWallet } from "./utils";
+import { expect, ethers, Contract, SignerWithAddress } from "./utils";
+import { toWei, advanceTime, seedAndApproveWallet, getContractFactory } from "./utils";
 import { acceleratingDistributorFixture, enableTokenForStaking } from "./AcceleratingDistributor.Fixture";
 import { baseEmissionRate, maxMultiplier, secondsToMaxMultiplier, stakeAmount } from "./constants";
 
@@ -23,11 +24,12 @@ describe("AcceleratingDistributor: Events", async function () {
   });
 
   it("RecoverErc20", async function () {
+    const randomToken = await (await getContractFactory("TestToken", owner)).deploy("RANDO", "RANDO");
     const amount = toWei(420);
-    await acrossToken.mint(distributor.address, amount);
-    await expect(distributor.recoverErc20(acrossToken.address, amount))
+    await randomToken.mint(distributor.address, amount);
+    await expect(distributor.recoverErc20(randomToken.address, amount))
       .to.emit(distributor, "RecoverErc20")
-      .withArgs(acrossToken.address, owner.address, amount);
+      .withArgs(randomToken.address, owner.address, amount);
   });
   it("Stake", async function () {
     const time1 = await distributor.getCurrentTime();


### PR DESCRIPTION
# Problem:
*H-01 Anyone can prevent stakers from getting their rewards*
The recoverErc20 function is meant to facilitate the recovery of any ERC20 tokens that maybe mistakenly sent to the AcceleratingDistributor contract. As this is a public function
with no modifiers, anyone can call this function to transfer an ERC20 token from the AcceleratingDistributor contract to the owner of AcceleratingDistributor . The
only ERC20 tokens that are explicitly disallowed from being recovered are stakedToken that have already been initialized in the system.

However, it is currently possible to recover the ERC20 rewardToken using the recoverErc20 function. Doing so would transfer some specified amount of rewardToken
from the AcceleratingDistributor contract to the contract's owner. This would, subsequently, prevent stakers from being able to access their rewards because
AcceleratingDistributor could be left with an insufficient balance of rewardToken s.

Even if the owner were to send rewardToken s back to the AcceleratingDistributor
contract, a malicious actor could immediately transfer all of the rewardTokens back to the
owner. Redeployment would be necessary to fix the issue.

# Solution:
An additional modifier was added to check the `tokenAddress` in the `recoverErc20` method is not the reward token. Tests were also updated
