### PR TITLE
fix m01: addition of more input validation

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -98,7 +98,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
         uint256 secondsToMaxMultiplier
     ) public onlyOwner {
         // Validate input to ensure system stability and avoid unexpected behavior. Note we dont place a lower bound on
-        // the baseEmissionRate. If this value is less than 1 then you will slowly loose your staking rewards over time.
+        // the baseEmissionRate. If this value is less than 1e18 then you will slowly loose your staking rewards over time.
         // Because of the way balances are managed, the staked token cannot be the reward token. Otherwise, reward
         // payouts could eat into user balances.
         require(stakedToken != address(rewardToken), "Staked token is reward token");

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -97,14 +97,14 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
         uint256 maxMultiplier,
         uint256 secondsToMaxMultiplier
     ) public onlyOwner {
-        // Validate input to ensure system stability and avoid unexpected behavior.
+        // Validate input to ensure system stability and avoid unexpected behavior. Note we dont place a lower bound on
+        // the baseEmissionRate. If this value is less than 1 then you will slowly loose your staking rewards over time.
         // Because of the way balances are managed, the staked token cannot be the reward token. Otherwise, reward
         // payouts could eat into user balances.
         require(stakedToken != address(rewardToken), "Staked token is reward token");
-        require(maxMultiplier > 1e18, "maxMultiplier be larger than 1");
-        require(maxMultiplier < 1000000000e18, "maxMultiplier can not be set too large");
+        require(maxMultiplier < 1e36, "maxMultiplier can not be set too large");
         require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier must be greater than 0");
-        require(baseEmissionRate < 1000000000e18, "baseEmissionRate can not be set too large");
+        require(baseEmissionRate < 1e27, "baseEmissionRate can not be set too large");
 
         StakingToken storage stakingToken = stakingTokens[stakedToken];
 

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -97,9 +97,14 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
         uint256 maxMultiplier,
         uint256 secondsToMaxMultiplier
     ) public onlyOwner {
+        // Validate input to ensure system stability and avoid unexpected behavior.
         // Because of the way balances are managed, the staked token cannot be the reward token. Otherwise, reward
         // payouts could eat into user balances.
         require(stakedToken != address(rewardToken), "Staked token is reward token");
+        require(maxMultiplier > 1e18, "maxMultiplier be larger than 1");
+        require(maxMultiplier < 1000000000e18, "maxMultiplier can not be set too large");
+        require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier must be greater than 0");
+        require(baseEmissionRate < 1000000000e18, "baseEmissionRate can not be set too large");
 
         StakingToken storage stakingToken = stakingTokens[stakedToken];
 

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -46,7 +46,7 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
   });
   it("Cannot set bad staking configs", async function () {
     await expect(
-      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(10000000000), secondsToMaxMultiplier)
+      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(toWei(1)), secondsToMaxMultiplier)
     ).to.be.revertedWith("maxMultiplier can not be set too large");
     await expect(
       distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, 0)

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -46,9 +46,6 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
   });
   it("Cannot set bad staking configs", async function () {
     await expect(
-      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(0.5), secondsToMaxMultiplier)
-    ).to.be.revertedWith("maxMultiplier be larger than 1");
-    await expect(
       distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(10000000000), secondsToMaxMultiplier)
     ).to.be.revertedWith("maxMultiplier can not be set too large");
     await expect(

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -2,7 +2,7 @@ import { expect, ethers, Contract, SignerWithAddress, toWei, toBN } from "./util
 import { acceleratingDistributorFixture } from "./AcceleratingDistributor.Fixture";
 import { baseEmissionRate, maxMultiplier, secondsToMaxMultiplier } from "./constants";
 
-let timer: Contract, acrossToken: Contract, distributor: Contract, lpToken1: Contract, lpToken2: Contract;
+let timer: Contract, acrossToken: Contract, distributor: Contract, lpToken1: Contract;
 let owner: SignerWithAddress, rando: SignerWithAddress;
 
 describe("AcceleratingDistributor: Admin Functions", async function () {
@@ -43,6 +43,20 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
     await expect(
       distributor.enableStaking(acrossToken.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier)
     ).to.be.revertedWith("Staked token is reward token");
+  });
+  it("Cannot set bad staking configs", async function () {
+    await expect(
+      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(0.5), secondsToMaxMultiplier)
+    ).to.be.revertedWith("maxMultiplier be larger than 1");
+    await expect(
+      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(10000000000), secondsToMaxMultiplier)
+    ).to.be.revertedWith("maxMultiplier can not be set too large");
+    await expect(
+      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, 0)
+    ).to.be.revertedWith("secondsToMaxMultiplier must be greater than 0");
+    await expect(
+      distributor.enableStaking(lpToken1.address, true, toWei(10000000000), maxMultiplier, secondsToMaxMultiplier)
+    ).to.be.revertedWith("baseEmissionRate can not be set too large");
   });
 
   it("Non owner cant execute admin functions", async function () {


### PR DESCRIPTION
# Problem:
﻿*The codebase generally lacks sufficient input validation.*
In the AcceleratingDistributor contract, the enableStaking function allows the
contract owner to configure several parameters associated with a stakedToken . Several of these parameters have no input checking. Specifically:

- The maxMultiplier parameter has no upper or lower bound.
- It should be restricted to being larger than the "base multiplier" of 1e18 , or else it can lead to users' staking rewards decreasing over time rather than increasing.
- It should also have an upper bound, because if it were to be set to some very large value it could cause the getUserRewardMultiplier function to revert on overflow. This
could, in turn, cause calls to the getOutstandingRewards and _updateReward functions to revert. This would interfere with the normal operation of the system.
However, it could be fixed by the contract owner using the enableStaking function to update to a more reasonable maxMultiplier .
- Similarly, the secondsToMaxMultiplier parameter has no lower bound. If allowed to be zero then getUserRewardMultiplier could revert due to division by zero. This
could cause the getOutstandingRewards and _updateReward functions to revert as outlined above. The contract owner could put the system back into a stable state by
making secondsToMaxMultiplier non-zero.
- The baseEmissionRate parameter has no upper bound. If set too high then, as soon as stakingToken.cumulativeStaked were some non-zero value, the
baseRewardPerToken function would always revert due to an overflow. Importantly, this value could be set to a system destabilizing value even when
stakingToken.cumulativeStaked was already non-zero. This would cause _updateReward to revert even in the case that the provided account was the zero
address. This detail would prevent the contract owner from fixing the situation without acomplete redeployment of the system if any stakedToken at all were actively being
staked. Any stakedToken already in the contract would be locked. To avoid errors and unexpected system behavior, consider implementing require statements
to validate all user-controlled input.

# Solution:
Additional input validation added on admin method `enableStaking`.

It must be noted that some of the changes recommend by OZ are pretty redundant here as the admin is the person setting them an all bad configs can be recovered by re-calling enableStaking. Equally, setting things like maxMultipler to be strictly greater than 1e18 prevents the contract from doing things that it might be intended to be used for, such as decreasing user balance over time. There might be cases where this is desired behavior. Nevertheless, all recommendations where added.
