### PR TITLE
fix l01: addition event information

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -65,18 +65,39 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      **************************************/
 
     event TokenEnabledForStaking(
-        address token,
+        address indexed token,
         bool enabled,
         uint256 baseEmissionRate,
         uint256 maxMultiplier,
         uint256 secondsToMaxMultiplier,
         uint256 lastUpdateTime
     );
-    event RecoverErc20(address token, address to, uint256 amount);
-    event Stake(address token, address user, uint256 amount, uint256 averageDepositTime, uint256 cumulativeBalance);
-    event Unstake(address token, address user, uint256 amount, uint256 remainingCumulativeBalance);
-    event GetReward(address token, address user, uint256 rewardsToSend);
-    event Exit(address token, address user);
+    event RecoverErc20(address indexed token, address indexed to, uint256 amount, address indexed caller);
+    event Stake(
+        address indexed token,
+        address indexed user,
+        uint256 amount,
+        uint256 averageDepositTime,
+        uint256 cumulativeBalance,
+        uint256 tokenCumulativeStaked
+    );
+    event Unstake(
+        address indexed token,
+        address indexed user,
+        uint256 amount,
+        uint256 remainingCumulativeBalance,
+        uint256 tokenCumulativeStaked
+    );
+    event GetReward(
+        address indexed token,
+        address indexed user,
+        uint256 rewardsToSend,
+        uint256 tokenLastUpdateTime,
+        uint256 tokenRewardPerTokenStored,
+        uint256 userRewardsOutstanding,
+        uint256 userRewardsPaidPerToken
+    );
+    event Exit(address indexed token, address indexed user, uint256 tokenCumulativeStaked);
 
     /**************************************
      *          ADMIN FUNCTIONS           *
@@ -132,7 +153,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
         require(stakingTokens[tokenAddress].lastUpdateTime == 0, "Can't recover staking token");
         IERC20(tokenAddress).safeTransfer(owner(), amount);
 
-        emit RecoverErc20(tokenAddress, owner(), amount);
+        emit RecoverErc20(tokenAddress, owner(), amount, msg.sender);
     }
 
     /**************************************
@@ -158,7 +179,14 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
 
         IERC20(stakedToken).safeTransferFrom(msg.sender, address(this), amount);
 
-        emit Stake(stakedToken, msg.sender, amount, averageDepositTime, userDeposit.cumulativeBalance);
+        emit Stake(
+            stakedToken,
+            msg.sender,
+            amount,
+            averageDepositTime,
+            userDeposit.cumulativeBalance,
+            stakingTokens[stakedToken].cumulativeStaked
+        );
     }
 
     /**
@@ -176,7 +204,13 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
 
         IERC20(stakedToken).transfer(msg.sender, amount);
 
-        emit Unstake(stakedToken, msg.sender, amount, userDeposit.cumulativeBalance);
+        emit Unstake(
+            stakedToken,
+            msg.sender,
+            amount,
+            userDeposit.cumulativeBalance,
+            stakingTokens[stakedToken].cumulativeStaked
+        );
     }
 
     /**
@@ -195,7 +229,15 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
             rewardToken.safeTransfer(msg.sender, rewardsToSend);
         }
 
-        emit GetReward(stakedToken, msg.sender, rewardsToSend);
+        emit GetReward(
+            stakedToken,
+            msg.sender,
+            rewardsToSend,
+            stakingTokens[stakedToken].lastUpdateTime,
+            stakingTokens[stakedToken].rewardPerTokenStored,
+            userDeposit.rewardsOutstanding,
+            userDeposit.rewardsPaidPerToken
+        );
     }
 
     /**
@@ -208,7 +250,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
         unstake(stakedToken, stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance);
         getReward(stakedToken);
 
-        emit Exit(stakedToken, msg.sender);
+        emit Exit(stakedToken, msg.sender, stakingTokens[stakedToken].cumulativeStaked);
     }
 
     /**************************************


### PR DESCRIPTION
# Problem
* L-01 Incomplete and unindexed events*
Throughout the codebase, events are used to signify when changes are made to the state of the system. However, all of the existing events lack indexed parameters. Some events are
missing parameters necessary to fully indicate how the state was modified during a call.
Events lacking indexed parameters include:
The TokenEnabledForStaking , RecoverErc20 , Stake , Unstake , GetReward ,
and Exit events in the AcceleratingDistributor contract.

Event emissions which do not fully track state changes include:
- The RecoverErc20 event does not emit the caller, which may be of interest to those interested in calls to the recoverErc20 function where the event is emitted.
- The Stake , Unstake , and Exit events are emitted when a user calls the stake , unstake , or exit functions, respectively. These functions update the stakedToken 's cumulativeStaked value, but this is not emitted in the events. Similarly, these functions-as well as the getReward function - update a stakedToken 's lastUpdateTime and rewardPerTokenStored as well as a userDeposit 's rewardsOutstanding and rewardsPaidPerToken values, but these state changes are not captured by any associated event emissions.

Consider completely indexing existing events, adding new indexed parameters where they are lacking, and/or adding new events to facilitate off-chain services searching and filtering for events. Consider emitting all events in such a complete manner that they could be used to rebuild the state of the contract.

# Solution:
Additional indexing added to events as well as all recomended state modifications are now tracked.
