### PR TITLE
fix l03: address missing safeTransfer

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -174,7 +174,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
         userDeposit.cumulativeBalance -= amount;
         stakingTokens[stakedToken].cumulativeStaked -= amount;
 
-        IERC20(stakedToken).transfer(msg.sender, amount);
+        IERC20(stakedToken).safeTransfer(msg.sender, amount);
 
         emit Unstake(stakedToken, msg.sender, amount, userDeposit.cumulativeBalance);
     }


### PR DESCRIPTION
# Problem
L-03 Unhandled failures in token interactions
There are ERC20 transfer operations, executed over potentially untrusted ERC20 tokens, which are not correctly wrapped to ensure that they are always safe and behave as expected.

Specifically, for the transfer on line 177 of the AcceleratingDistributor contract, the current implementation does not handle a case where the call to transfer fails by returning
a false boolean value (rather than reverting the transaction).

For more predictable and consistent behavior, consider using the OpenZeppelin SafeERC20 library which is used for other transfers throughout the codebase, as it implements wrappers
around ERC20 operations that return false on failure.

# Solution
added the use of `safeTransfer` to the one line on 177 where this was missing.
