### PR TITLE
fix l03: removed unused contract

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -6,7 +6,6 @@ import "./test/Testable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Multicall.sol";
 
@@ -20,7 +19,7 @@ import "hardhat/console.sol";
  *
  */
 
-contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable, Multicall {
+contract AcceleratingDistributor is Testable, ReentrancyGuard, Ownable, Multicall {
     using SafeERC20 for IERC20;
 
     IERC20 public rewardToken;


### PR DESCRIPTION
# Problem
*L-04 Unused inherited contracts*
The AcceleratingDistributor contract imports and inherits from the Pausable contract but does not use any of the inherited functionality.

Consider either using the inherited Pausable functionality or else not inheriting from the Pausable contract.

# Solution
the `Pausable` contract was removed from the inherited path.
