### PR TITLE
fix n01: updated function visibility

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -230,7 +230,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      * @param account The address of user to query.
      * @return UserDeposit Struct with: {cumulativeBalance,averageDepositTime,rewardsPaidPerToken,rewardsOutstanding}
      */
-    function getUserStake(address stakedToken, address account) public view returns (UserDeposit memory) {
+    function getUserStake(address stakedToken, address account) external view returns (UserDeposit memory) {
         return stakingTokens[stakedToken].stakingBalances[account];
     }
 

--- a/contracts/AcrossToken.sol
+++ b/contracts/AcrossToken.sol
@@ -7,11 +7,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract AcrossToken is ERC20, Ownable {
     constructor() ERC20("Across Protocol Token", "ACX") {}
 
-    function mint(address _guy, uint256 _wad) public onlyOwner {
+    function mint(address _guy, uint256 _wad) external onlyOwner {
         _mint(_guy, _wad);
     }
 
-    function burn(address _guy, uint256 _wad) public onlyOwner {
+    function burn(address _guy, uint256 _wad) external onlyOwner {
         _burn(_guy, _wad);
     }
 }


### PR DESCRIPTION
# Problem:
*N-01 Visibility unnecessarily permissive*
The mint and burn functions of the AcrossToken contract and enableStaking , stake , getCumulativeStaked , and getUserStake of the
AcceleratingDistributor contract are marked as public , while they could be marked as external .

# Solution:
Updated mentioned functions to `external`.
