### PR TITLE
fix n02: updated comments around non-standard ERC20 tokens

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -16,8 +16,9 @@ import "hardhat/console.sol";
  * @notice Across token distribution contract. Contract is inspired by Synthetix staking contract and Ampleforth geyser.
  * Stakers start by earning their pro-rate share of a baseEmissionRate per second which increases based on how long
  * they have staked in the contract, up to a maximum of maxEmissionRate. Multiple LP tokens can be staked in this
- * contract enabling depositors to batch stake and claim via multicall.
- *
+ * contract enabling depositors to batch stake and claim via multicall. Note that this contract is only compatible with
+ * standard ERC20 tokens, and not tokens that charge fees on transfers or dynamically change ballance. It's up to the
+ * contract owner to ensure they only add supported tokens.
  */
 
 contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable, Multicall {
@@ -84,6 +85,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
 
     /**
      * @notice Enable a token for staking.
+     * @dev The owner should ensure that the token enabled is a standard ERC20 token to ensure correct functionality.
      * @param stakedToken The address of the token that can be staked.
      * @param enabled Whether the token is enabled for staking.
      * @param baseEmissionRate The base emission rate for staking the token. This is split pro-rate between all users.
@@ -128,7 +130,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      * @param tokenAddress The address of the token to recover.
      * @param amount The amount of the token to recover.
      */
-    function recoverErc20(address tokenAddress, uint256 amount) external {
+    function recoverErc20(address tokenAddress, uint256 amount) external nonReentrant {
         require(stakingTokens[tokenAddress].lastUpdateTime == 0, "Can't recover staking token");
         IERC20(tokenAddress).safeTransfer(owner(), amount);
 

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -230,7 +230,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      * @param account The address of user to query.
      * @return UserDeposit Struct with: {cumulativeBalance,averageDepositTime,rewardsPaidPerToken,rewardsOutstanding}
      */
-    function getUserStake(address stakedToken, address account) public view returns (UserDeposit memory) {
+    function getUserStake(address stakedToken, address account) external view returns (UserDeposit memory) {
         return stakingTokens[stakedToken].stakingBalances[account];
     }
 

--- a/contracts/AcrossToken.sol
+++ b/contracts/AcrossToken.sol
@@ -7,11 +7,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract AcrossToken is ERC20, Ownable {
     constructor() ERC20("Across Protocol Token", "ACX") {}
 
-    function mint(address _guy, uint256 _wad) public onlyOwner {
+    function mint(address _guy, uint256 _wad) external onlyOwner {
         _mint(_guy, _wad);
     }
 
-    function burn(address _guy, uint256 _wad) public onlyOwner {
+    function burn(address _guy, uint256 _wad) external onlyOwner {
         _burn(_guy, _wad);
     }
 }

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -81,13 +81,25 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
   });
   it("Cannot set bad staking configs", async function () {
     await expect(
-      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, toWei(toWei(1)), secondsToMaxMultiplier)
+      distributor.configureStakingToken(
+        lpToken1.address,
+        true,
+        baseEmissionRate,
+        toWei(toWei(1)),
+        secondsToMaxMultiplier
+      )
     ).to.be.revertedWith("maxMultiplier can not be set too large");
     await expect(
-      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, 0)
+      distributor.configureStakingToken(lpToken1.address, true, baseEmissionRate, maxMultiplier, 0)
     ).to.be.revertedWith("secondsToMaxMultiplier must be greater than 0");
     await expect(
-      distributor.enableStaking(lpToken1.address, true, toWei(10000000000), maxMultiplier, secondsToMaxMultiplier)
+      distributor.configureStakingToken(
+        lpToken1.address,
+        true,
+        toWei(10000000000),
+        maxMultiplier,
+        secondsToMaxMultiplier
+      )
     ).to.be.revertedWith("baseEmissionRate can not be set too large");
   });
 


### PR DESCRIPTION
# Problem: 
*N-02 System is incompatible with non-standard ERC20 tokens*
Currently, the system is incompatible with non-standard ERC20 tokens and enabling such tokens for staking could lead to loss of funds in the following ways:
1. The system's internal accounting mechanism does not currently support tokens that can charge fees on transfers, such as Tether (USDT) (the most widely known asset with this
feature). This means that such tokens' transfer and transferFrom functions could potentially fail to increase the recipient's balance by the amount that is actually transferred.

If AcceleratingDistributor allows staking of tokens charging such transfer fees, then stakers would receive more rewards than intended.

2. The recoverErc20 function is currently callable by any address. This could be problematic if the system were to allow staking of non-standard ERC20 tokens,
particularly if those tokens were to have a double entry point. In such a case the current restrictions may not be sufficient to restrict such tokens' recovery via the
recoverErc20 function (e.g. Compound-TUSD Integration Issue Retrospective).

If the protocol is expected to be compatible with these types of non-standard ERC20 tokens, then consider modifying the internal accounting mechanisms so that they properly track the
actual amount of assets deposited. Additionally, consider limiting the recoverErc20 function so that is can only be called from trusted accounts.

Alternatively, consider documenting that the system is incompatible with non-standard ERC20 tokens and ensuring the contract owner thoroughly vets any ERC20 tokens that are enabled for
staking. If the recoverErc20 function is left unrestricted, then consider moving it out of the ADMIN section of the codebase.

# Solution:
Comments were added to indicate that the admin must not add any non-standard tokens to the contract. To deal with non-standard tokens in the recoverErc20 function the `nonReentrant` modifier was added.
