### PR TITLE
fix n03: Address misleading function names

### DIFF
--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -13,7 +13,13 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
   it("Enable token for staking", async function () {
     expect((await distributor.stakingTokens(lpToken1.address)).enabled).to.be.false;
 
-    await distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier);
+    await distributor.configureStakingToken(
+      lpToken1.address,
+      true,
+      baseEmissionRate,
+      maxMultiplier,
+      secondsToMaxMultiplier
+    );
     expect((await distributor.stakingTokens(lpToken1.address)).enabled).to.be.true;
     expect((await distributor.stakingTokens(lpToken1.address)).baseEmissionRate).to.equal(baseEmissionRate);
     expect((await distributor.stakingTokens(lpToken1.address)).maxMultiplier).to.equal(maxMultiplier);
@@ -22,17 +28,35 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
 
     // Update settings.
     const newMultiplier = maxMultiplier.add(toWei(1));
-    await distributor.enableStaking(lpToken1.address, true, baseEmissionRate, newMultiplier, secondsToMaxMultiplier);
+    await distributor.configureStakingToken(
+      lpToken1.address,
+      true,
+      baseEmissionRate,
+      newMultiplier,
+      secondsToMaxMultiplier
+    );
     expect((await distributor.stakingTokens(lpToken1.address)).maxMultiplier).to.equal(newMultiplier);
 
     //Disable token for staking.
-    await distributor.enableStaking(lpToken1.address, false, baseEmissionRate, newMultiplier, secondsToMaxMultiplier);
+    await distributor.configureStakingToken(
+      lpToken1.address,
+      false,
+      baseEmissionRate,
+      newMultiplier,
+      secondsToMaxMultiplier
+    );
     expect((await distributor.stakingTokens(lpToken1.address)).enabled).to.be.false;
   });
 
   it("Can not recover staking tokens", async function () {
     // Should not be able to recover staking tokens.
-    await distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier);
+    await distributor.configureStakingToken(
+      lpToken1.address,
+      true,
+      baseEmissionRate,
+      maxMultiplier,
+      secondsToMaxMultiplier
+    );
     await lpToken1.mint(distributor.address, toWei(420));
     await expect(distributor.recoverErc20(lpToken1.address, toWei(420))).to.be.revertedWith(
       "Can't recover staking token"
@@ -41,12 +65,18 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
 
   it("Cannot set staking token to reward token", async function () {
     await expect(
-      distributor.enableStaking(acrossToken.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier)
+      distributor.configureStakingToken(
+        acrossToken.address,
+        true,
+        baseEmissionRate,
+        maxMultiplier,
+        secondsToMaxMultiplier
+      )
     ).to.be.revertedWith("Staked token is reward token");
   });
 
   it("Non owner cant execute admin functions", async function () {
-    await expect(distributor.connect(rando).enableStaking(lpToken1.address, true, 4, 2, 0)).to.be.revertedWith(
+    await expect(distributor.connect(rando).configureStakingToken(lpToken1.address, true, 4, 2, 0)).to.be.revertedWith(
       "Ownable: caller is not the owner"
     );
   });
@@ -56,23 +86,35 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
     await expect(distributor.connect(owner).unstake(lpToken1.address, 0)).to.be.revertedWith(
       "stakedToken not initialized"
     );
-    await expect(distributor.connect(owner).getReward(lpToken1.address)).to.be.revertedWith(
+    await expect(distributor.connect(owner).withdrawReward(lpToken1.address)).to.be.revertedWith(
       "stakedToken not initialized"
     );
     await expect(distributor.connect(owner).exit(lpToken1.address)).to.be.revertedWith("stakedToken not initialized");
 
-    await distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier);
+    await distributor.configureStakingToken(
+      lpToken1.address,
+      true,
+      baseEmissionRate,
+      maxMultiplier,
+      secondsToMaxMultiplier
+    );
 
     await expect(distributor.connect(owner).stake(lpToken1.address, 0)).to.not.be.reverted;
     await expect(distributor.connect(owner).unstake(lpToken1.address, 0)).to.not.be.reverted;
-    await expect(distributor.connect(owner).getReward(lpToken1.address)).to.not.be.reverted;
+    await expect(distributor.connect(owner).withdrawReward(lpToken1.address)).to.not.be.reverted;
     await expect(distributor.connect(owner).exit(lpToken1.address)).to.not.be.reverted;
 
-    await distributor.enableStaking(lpToken1.address, false, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier);
+    await distributor.configureStakingToken(
+      lpToken1.address,
+      false,
+      baseEmissionRate,
+      maxMultiplier,
+      secondsToMaxMultiplier
+    );
 
     await expect(distributor.connect(owner).stake(lpToken1.address, 0)).to.be.revertedWith("stakedToken not enabled");
     await expect(distributor.connect(owner).unstake(lpToken1.address, 0)).to.not.be.reverted;
-    await expect(distributor.connect(owner).getReward(lpToken1.address)).to.not.be.reverted;
+    await expect(distributor.connect(owner).withdrawReward(lpToken1.address)).to.not.be.reverted;
     await expect(distributor.connect(owner).exit(lpToken1.address)).to.not.be.reverted;
   });
 });

--- a/test/AcceleratingDistributor.Events.ts
+++ b/test/AcceleratingDistributor.Events.ts
@@ -13,12 +13,12 @@ describe("AcceleratingDistributor: Events", async function () {
     await enableTokenForStaking(distributor, lpToken1, acrossToken);
     await seedAndApproveWallet(depositor1, [lpToken1], distributor);
   });
-  it("EnableStaking", async function () {
+  it("configureStakingToken", async function () {
     const currentTime = await distributor.getCurrentTime();
     await expect(
-      distributor.enableStaking(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier)
+      distributor.configureStakingToken(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier)
     )
-      .to.emit(distributor, "TokenEnabledForStaking")
+      .to.emit(distributor, "TokenConfiguredForStaking")
       .withArgs(lpToken1.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier, currentTime);
   });
 
@@ -64,8 +64,8 @@ describe("AcceleratingDistributor: Events", async function () {
 
     // Advance 200. should be entitled to 200 * 0.01 * (1 + 200 / 1000 * (5 - 1)) = 3.6
     await advanceTime(timer, 200);
-    await expect(distributor.connect(depositor1).getReward(lpToken1.address))
-      .to.emit(distributor, "GetReward")
+    await expect(distributor.connect(depositor1).withdrawReward(lpToken1.address))
+      .to.emit(distributor, "RewardsWithdrawn")
       .withArgs(lpToken1.address, depositor1.address, toWei(3.6));
   });
   it("Exit", async function () {

--- a/test/AcceleratingDistributor.Events.ts
+++ b/test/AcceleratingDistributor.Events.ts
@@ -81,7 +81,7 @@ describe("AcceleratingDistributor: Events", async function () {
     // Reward paid per token should be 200 * 0.01 or 0.2.
     await advanceTime(timer, 200);
     const currentTime = await distributor.getCurrentTime();
-    await expect(distributor.connect(depositor1).getReward(lpToken1.address))
+    await expect(distributor.connect(depositor1).withdrawReward(lpToken1.address))
       .to.emit(distributor, "RewardsWithdrawn")
       .withArgs(lpToken1.address, depositor1.address, toWei(3.6), currentTime, toWei(0.2), 0, toWei(0.2));
   });

--- a/test/AcceleratingDistributor.Fixture.ts
+++ b/test/AcceleratingDistributor.Fixture.ts
@@ -20,6 +20,12 @@ export const acceleratingDistributorFixture = hre.deployments.createFixture(asyn
 
 export async function enableTokenForStaking(distributor: Contract, lpToken: Contract, acrossToken: Contract) {
   // Enable the LpToken for staking and deposit some across tokens into the distributor.
-  await distributor.enableStaking(lpToken.address, true, baseEmissionRate, maxMultiplier, secondsToMaxMultiplier);
+  await distributor.configureStakingToken(
+    lpToken.address,
+    true,
+    baseEmissionRate,
+    maxMultiplier,
+    secondsToMaxMultiplier
+  );
   await acrossToken.mint(distributor.address, seedDistributorAmount);
 }

--- a/test/AcceleratingDistributor.RewardAccumulation.ts
+++ b/test/AcceleratingDistributor.RewardAccumulation.ts
@@ -61,11 +61,11 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
     // get 20 / 40 * 3.6 = 2.7. Equally, both should have the same multiplier of 1 + 200 / 1000 *(5 - 1) = 1.8
     await advanceTime(timer, 200);
     expect(await distributor.getUserRewardMultiplier(lpToken1.address, depositor1.address)).to.equal(toWei(1.8));
-    await expect(() => distributor.connect(depositor1).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor1).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 0.9 to the depositor1.
       .to.changeTokenBalances(acrossToken, [distributor, depositor1], [toWei(-0.9), toWei(0.9)]);
     expect(await distributor.getUserRewardMultiplier(lpToken1.address, depositor2.address)).to.equal(toWei(1.8));
-    await expect(() => distributor.connect(depositor2).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor2).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 2.7 to the depositor2.
       .to.changeTokenBalances(acrossToken, [distributor, depositor2], [toWei(-2.7), toWei(2.7)]);
   });
@@ -79,7 +79,7 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
     expect(await distributor.getUserRewardMultiplier(lpToken1.address, depositor2.address)).to.equal(toWei(1.8));
 
     // Claim on just depositor2.
-    await distributor.connect(depositor2).getReward(lpToken1.address);
+    await distributor.connect(depositor2).withdrawReward(lpToken1.address);
     expect(await distributor.getUserRewardMultiplier(lpToken1.address, depositor1.address)).to.equal(toWei(1.8));
     expect(await distributor.getUserRewardMultiplier(lpToken1.address, depositor2.address)).to.equal(toWei(1));
 
@@ -91,12 +91,12 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
 
     // Depositor1 should now be entitled to 1/4 of the rewards accumulated over the period, multiplied by their multiplier.
     // This should be 500 * 0.01 * 3 * 1/4 = 3.75.
-    await expect(() => distributor.connect(depositor1).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor1).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 3.75 to the depositor1.
       .to.changeTokenBalances(acrossToken, [distributor, depositor1], [toWei(-3.75), toWei(3.75)]);
     // Depositor2 should be entitled to 3/4th of of the rewards, accumulated from the previous time they claimed, multiple
     // by their reduced multiplier. This should be 300 * 0.01 * 2.2 * 3/4 = 4.95
-    await expect(() => distributor.connect(depositor2).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor2).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 4.49 to the depositor2.
       .to.changeTokenBalances(acrossToken, [distributor, depositor2], [toWei(-4.95), toWei(4.95)]);
   });

--- a/test/AcceleratingDistributor.RewardTokenFlow.ts
+++ b/test/AcceleratingDistributor.RewardTokenFlow.ts
@@ -19,7 +19,7 @@ describe("AcceleratingDistributor: Reward Token Flow", async function () {
     // Advance time 200 seconds. Expected rewards are 200 * 0.01 * (1 + 200 / 1000 * (5 - 1)) = 3.6.
     await advanceTime(timer, 200);
 
-    await expect(() => distributor.connect(depositor1).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor1).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 3.6 to the depositor.
       .to.changeTokenBalances(acrossToken, [distributor, depositor1], [toWei(-3.6), toWei(3.6)]);
 
@@ -28,7 +28,7 @@ describe("AcceleratingDistributor: Reward Token Flow", async function () {
 
     // Advance time 500 seconds. Expected rewards are 500 * 0.01 * (1 + 500 / 1000 * (5 - 1)) = 15.
     await advanceTime(timer, 500);
-    await expect(() => distributor.connect(depositor1).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor1).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 15 to the depositor.
       .to.changeTokenBalances(acrossToken, [distributor, depositor1], [toWei(-15), toWei(15)]);
   });
@@ -69,7 +69,7 @@ describe("AcceleratingDistributor: Reward Token Flow", async function () {
     await expect(() => distributor.connect(depositor1).unstake(lpToken1.address, stakeAmount))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 0.9 to the depositor1.
       .to.changeTokenBalances(lpToken1, [distributor, depositor1], [stakeAmount.mul(-1), stakeAmount]);
-    await expect(() => distributor.connect(depositor1).getReward(lpToken1.address))
+    await expect(() => distributor.connect(depositor1).withdrawReward(lpToken1.address))
       // Get the rewards. Check the cash flows are as expected. The distributor should send 10.2 to the depositor1.
       .to.changeTokenBalances(acrossToken, [distributor, depositor1], [toWei(10.2).mul(-1), toWei(10.2)]);
     expect(await distributor.getOutstandingRewards(lpToken1.address, depositor1.address)).to.equal(toWei(0));

--- a/test/AcceleratingDistributor.TimeEvolution.ts
+++ b/test/AcceleratingDistributor.TimeEvolution.ts
@@ -20,7 +20,7 @@ describe("AcceleratingDistributor: Time Evolution", async function () {
     // see the users averageDeposit time be time1 + 210 seconds (half way between the two deposits).
     await advanceTime(timer, 420);
     const time2 = await distributor.getCurrentTime();
-    expect(await distributor.getTimeFromLastDeposit(lpToken1.address, depositor1.address)).to.equal(420);
+    expect(await distributor.getTimeSinceAverageDeposit(lpToken1.address, depositor1.address)).to.equal(420);
     await distributor.connect(depositor1).stake(lpToken1.address, stakeAmount);
     const averageDepositTime1 = time1.add(210);
     expect(time2).to.equal(time1.add(420));


### PR DESCRIPTION
# Problem:
*N-03 Misleading function names*
In the AcceleratingDistributor contract there are multiple functions, storage variables, and events that have misleading names. These could potentially confuse users and lead to
unintentional or unexpected consequences when interacting with the contract. For instance:
- The function name enableStaking implies that it can only be used to enable a staking token. However, the function can be used to enable or disable a staking token, and/or
modify the properties baseEmissionRate , maxMultiplier or secondsToMaxMultiplier . Consider renaming the function to configureStakingToken .
- The enableStaking function emits the event TokenEnabledForStaking . Consider renaming the event to better reflect the actual use case of the emitting function as
outlined in the above bullet point.
- The function prefix get typically indicates a view function, however the function getReward transfers outstanding rewards to the caller. Consider renaming it to
withdrawReward.
- The function name getTimeFromLastDeposit implies that a difference between the current time and the last time of deposit is returned. However, the difference is
calculated using the weighted average deposit time. Consider renaming it to getTimeSinceAverageDeposit .
- The variable name rewardsPaidPerToken appears to imply that the rewards contained can be distributed or have already been distributed to the individual user.
However, this variable is used as a helper variable to allow accurate bookkeeping of the rewardsOustanding variable, which contains the funds that are actually withdrawable
to the individual user. Consider renaming rewardsPaidPerToken to rewardsAccumulatedPerToken .

# Solution:
All recomendations were added.
