### PR TITLE
fix n04: N-04 Missing documentation details

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -15,8 +15,8 @@ import "hardhat/console.sol";
 /**
  * @notice Across token distribution contract. Contract is inspired by Synthetix staking contract and Ampleforth geyser.
  * Stakers start by earning their pro-rate share of a baseEmissionRate per second which increases based on how long
- * they have staked in the contract, up to a maximum of maxEmissionRate. Multiple LP tokens can be staked in this
- * contract enabling depositors to batch stake and claim via multicall.
+ * they have staked in the contract, up to a maximum of max emission rate of the base baseEmissionRate * maxMultiplier.
+ * Multiple LP tokens can be staked in this contract enabling depositors to batch stake and claim via multicall.
  *
  */
 
@@ -237,6 +237,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
     /**
      * @notice Returns the base rewards per staked token for a given staking token. This factors in the last time
      * any internal logic was called on this contract to correctly attribute retroactive cumulative rewards.
+     * @dev the value returned is represented by a uint256 with fixed precision of 18 decimals.
      * @param stakedToken The address of the staked token to query.
      * @return uint256 Total base reward per token that will be applied, pro-rata, to stakers.
      */
@@ -254,6 +255,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      * @notice Returns the multiplier applied to the base reward per staked token for a given staking token and account.
      * The longer a user stakes the higher their multiplier up to maxMultiplier for that given staking token.
      * any internal logic was called on this contract to correctly attribute retroactive cumulative rewards.
+     * @dev the value returned is represented by a uint256 with fixed precision of 18 decimals.
      * @param stakedToken The address of the staked token to query.
      * @param account The address of the user to query.
      * @return uint256 User multiplier, applied to the baseRewardPerToken, when claiming rewards.


### PR DESCRIPTION
# Problem
*N-04 Missing documentation details*
In the AcceleratingDistributor contract several parts of the documentation contain missing or misleading details. For instance:
- The functions getUserRewardMultiplier and baseRewardPerToken return ratios or multipliers represented by a uint256 value with a fixed precision of 18 decimals. However, the decimal precision used is not documented.
The contract-level documentation refers to a maxEmissionRate . However, the implementation uses a maxMultiplier which is multiplied with a baseEmissionRate instead.
- To increase the overall readability of the codebase and reduce potential confusion, consider clarifying the documentation and adding missing details where appropriate.

# Solution
All recommendations have been implemented.
