### PR TITLE
fix n05: mark immutable variables as immutable

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -23,7 +23,7 @@ import "hardhat/console.sol";
 contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable, Multicall {
     using SafeERC20 for IERC20;
 
-    IERC20 public rewardToken;
+    IERC20 public immutable rewardToken;
 
     // Each User deposit is tracked with the information below.
     struct UserDeposit {


### PR DESCRIPTION
# Problem
In the AcceleratingDistributor contract the rewardToken variable could be marked immutable given that is only ever set in the constructor.

If rewardToken is never meant to be modifiable, then consider marking it immutable to better signal intent and reduce gas consumption.

# Solution
Recommendation done.
