### PR TITLE
fix n06: remove test code in production version

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -20,7 +20,7 @@ import "hardhat/console.sol";
  *
  */
 
-contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable, Multicall {
+contract AcceleratingDistributor_Testable is Testable, ReentrancyGuard, Pausable, Ownable, Multicall {
     using SafeERC20 for IERC20;
 
     IERC20 public rewardToken;
@@ -331,5 +331,17 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
             userDeposit.rewardsOutstanding = getOutstandingRewards(stakedToken, account);
             userDeposit.rewardsPaidPerToken = stakingToken.rewardPerTokenStored;
         }
+    }
+}
+
+// Production version of the AcceleratingDistributor that forces the timer address to 0 to ensure no posable misconfiguration.
+contract AcceleratingDistributor is AcceleratingDistributor_Testable {
+    constructor(address _rewardToken)
+        AcceleratingDistributor_Testable(_rewardToken, 0x0000000000000000000000000000000000000000)
+    {}
+
+    // Override Testable implementation of the same logic for small gas saving.
+    function getCurrentTime() public view override returns (uint256) {
+        return block.timestamp; // solhint-disable-line not-rely-on-time
     }
 }

--- a/contracts/test/Testable.sol
+++ b/contracts/test/Testable.sol
@@ -43,10 +43,7 @@ abstract contract Testable {
      * @return uint for the current Testable timestamp.
      */
     function getCurrentTime() public view virtual returns (uint256) {
-        if (timerAddress != address(0x0)) {
-            return Timer(timerAddress).getCurrentTime();
-        } else {
-            return block.timestamp; // solhint-disable-line not-rely-on-time
-        }
+        if (timerAddress != address(0x0)) return Timer(timerAddress).getCurrentTime();
+        else return block.timestamp; // solhint-disable-line not-rely-on-time
     }
 }

--- a/test/AcceleratingDistributor.Fixture.ts
+++ b/test/AcceleratingDistributor.Fixture.ts
@@ -9,7 +9,7 @@ export const acceleratingDistributorFixture = hre.deployments.createFixture(asyn
   const acrossToken = await (await getContractFactory("AcrossToken", deployerWallet)).deploy();
 
   const distributor = await (
-    await getContractFactory("AcceleratingDistributor", deployerWallet)
+    await getContractFactory("AcceleratingDistributor_Testable", deployerWallet)
   ).deploy(acrossToken.address, timer.address);
 
   const lpToken1 = await (await getContractFactory("TestToken", deployerWallet)).deploy("LP1", "LP Token 1");


### PR DESCRIPTION
# Problem:
*N-06 Test code in production could have security implications*
As we have raised in prior audits (issue L12) test code in production code is less than ideal. We will not simply rehash our previously raised concerns and suggestions, but we do feel it
prudent to expound on some of the potential security implications of having test code in production in this particular case:

The AcceleratingDistributor contract inherits from the Testable contract. This facilitates modification of the getCurrentTime function's behavior during testing. This
inheritance is meant to be kept in production. This is considered safe because passing the zero address for the parameter _timer during deployment will disable the testing module and
return block.timestamp instead. 

The contract logic ensures that all staked tokens can be unstaked by their respective owners and that all rewards can be collected even if further staking is disabled by the contract owner. Calls to unstake and getReward are guarded by a modifier which ensures only that a token
had been enabled for staking at some time - not that it is currently enabled for staking. It does this by verifying the token's lastUpdateTime is greater than zero. The contract owner is not
meant to be able to set lastUpdateTime in production and it is guaranteed to be greater than zero for each token that has previously been enabled for staking.

However, a malicious operator could deploy the code with the address _timer pointing to a smart contract that allows the attacker to arbitrarily change time. They could at first report
accurate block times and then wait until a significant portion of staked TVL is accumulated. Later, they could change the reported time to zero. As a consequence, users would be unable
to unstake or obtain rewards. What's worse, the malicious operator could then steal all staked TVL via recoverERC20 (which would no longer recognize the staked token as such when
their lastUpdateTime was equal to zero).

A potential risk here is that a third party could uses this exact code, misusing the Testable functionality to be genuinely malicious. Since ecosystem tools such as Etherscan can do exact
matching on bytecode, the malicious deployment could end up being directly linked to the Across protocol, which could lead to some loss of reputation.
As this is a fairly general-purpose, user-facing system, with an open source license, we can certainly imagine it being reused. The subtleties of the deployment can have drastic
implications for the security model of the deployed system. Normalizing such designs can have unintended consequences for users, but also for projects that may inadvertently suffer from
mere association with some malicious deployment.

Consider better isolating test and production code where possible. When this is not possible, consider bolstering the warnings in the code so that even casual users could better understand
the implications if system variables are are not set as intended in production.

# Solution:
As this contract is released to be generally used by anyone, there is indeed a risk of misparapaterization. The solution added in this PR is to create a `AcceleratingDistributor_Testable` version of the contract that lets the timer address be set and a base `AcceleratingDistributor` where the `getCurrentTime` method does nothing more than return `block.timestamp`. This prevents any kind of misparamertrization when deploying the actual `AcceleratingDistributor` contract.
