### PR TITLE
fix n07: addressed typographical errors

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -14,7 +14,7 @@ import "hardhat/console.sol";
 
 /**
  * @notice Across token distribution contract. Contract is inspired by Synthetix staking contract and Ampleforth geyser.
- * Stakers start by earning their pro-rate share of a baseEmissionRate per second which increases based on how long
+ * Stakers start by earning their pro-rata share of a baseEmissionRate per second which increases based on how long
  * they have staked in the contract, up to a maximum of maxEmissionRate. Multiple LP tokens can be staked in this
  * contract enabling depositors to batch stake and claim via multicall.
  *
@@ -86,7 +86,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
      * @notice Enable a token for staking.
      * @param stakedToken The address of the token that can be staked.
      * @param enabled Whether the token is enabled for staking.
-     * @param baseEmissionRate The base emission rate for staking the token. This is split pro-rate between all users.
+     * @param baseEmissionRate The base emission rate for staking the token. This is split pro-rata between all users.
      * @param maxMultiplier The maximum multiplier for staking which increases your rewards the longer you stake.
      * @param secondsToMaxMultiplier The number of seconds needed to stake to reach the maximum multiplier.
      */
@@ -123,7 +123,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
     }
 
     /**
-     * @notice Recover an ERC20 token either dropped on the contract or excess after the end of the staking program ends.
+     * @notice Recover an ERC20 token either dropped on the contract or excess after the staking program ends.
      * @dev Any wallet can call this function as it will only ever send tokens to the owner of the distributor.
      * @param tokenAddress The address of the token to recover.
      * @param amount The amount of the token to recover.
@@ -181,7 +181,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
 
     /**
      * @notice Get entitled rewards for the staker.
-     * @dev Calling this method will reset the callers reward multiplier.
+     * @dev Calling this method will reset the caller's reward multiplier.
      * @param stakedToken The address of the token to get rewards for.
      */
     function getReward(address stakedToken) public nonReentrant onlyInitialized(stakedToken) {
@@ -199,8 +199,8 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
     }
 
     /**
-     * @notice Exits a staking position by unstaking and getting rewards. This totally exists the staking position.
-     * @dev Calling this method will reset the callers reward multiplier.
+     * @notice Exits a staking position by unstaking and getting rewards. This totally exits the staking position.
+     * @dev Calling this method will reset the caller's reward multiplier.
      * @param stakedToken The address of the token to get rewards for.
      */
     function exit(address stakedToken) external onlyInitialized(stakedToken) {
@@ -225,7 +225,7 @@ contract AcceleratingDistributor is Testable, ReentrancyGuard, Pausable, Ownable
     }
 
     /**
-     * @notice Returns the all information associated with a user's stake.
+     * @notice Returns all the information associated with a user's stake.
      * @param stakedToken The address of the staked token to query.
      * @param account The address of user to query.
      * @return UserDeposit Struct with: {cumulativeBalance,averageDepositTime,rewardsPaidPerToken,rewardsOutstanding}

--- a/test/AcceleratingDistributor.RewardAccumulation.ts
+++ b/test/AcceleratingDistributor.RewardAccumulation.ts
@@ -51,7 +51,7 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
     // Rewards entitled to the user should now be duration * baseEmissionRate * multiplier as 1000 * 0.01 * 5 = 50
     expect(await distributor.getOutstandingRewards(lpToken1.address, depositor1.address)).to.equal(toWei(50));
   });
-  it("Multiple depositors, pro-rate distribution: same stake time and claim time", async function () {
+  it("Multiple depositors, pro-rata distribution: same stake time and claim time", async function () {
     // Create a simple situation wherein both depositors deposit at the same time but have varying amounts.
     await distributor.connect(depositor1).stake(lpToken1.address, stakeAmount); // stake 10.
     await distributor.connect(depositor2).stake(lpToken1.address, stakeAmount.mul(3)); // stake 30.
@@ -69,7 +69,7 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
       // Get the rewards. Check the cash flows are as expected. The distributor should send 2.7 to the depositor2.
       .to.changeTokenBalances(acrossToken, [distributor, depositor2], [toWei(-2.7), toWei(2.7)]);
   });
-  it("Multiple depositors, pro-rate distribution: same stake time and separate claim time", async function () {
+  it("Multiple depositors, pro-rata distribution: same stake time and separate claim time", async function () {
     await distributor.connect(depositor1).stake(lpToken1.address, stakeAmount); // stake 10.
     await distributor.connect(depositor2).stake(lpToken1.address, stakeAmount.mul(3)); // stake 30.
     // Try claiming from one user halfway through some staking period and validating that multipliers are treated independently.
@@ -100,9 +100,9 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
       // Get the rewards. Check the cash flows are as expected. The distributor should send 4.49 to the depositor2.
       .to.changeTokenBalances(acrossToken, [distributor, depositor2], [toWei(-4.95), toWei(4.95)]);
   });
-  it("Multiple depositors, pro-rate distribution: separate stake time and separate claim time", async function () {
+  it("Multiple depositors, pro-rata distribution: separate stake time and separate claim time", async function () {
     // Stake with one user, advance time, then stake with another use. We should be able to track the evaluation of the
-    // pro-rate rewards, as expected.
+    // pro-rata rewards, as expected.
 
     await distributor.connect(depositor1).stake(lpToken1.address, stakeAmount); // stake 10.
     await advanceTime(timer, 200);
@@ -117,10 +117,10 @@ describe("AcceleratingDistributor: Staking Rewards", async function () {
     // Advance time another 200 seconds.
     await advanceTime(timer, 200);
 
-    // Now, the depositor1 should be entitled to their first amount + the pro-rate rewards for the second period as
+    // Now, the depositor1 should be entitled to their first amount + the pro-rata rewards for the second period as
     // 400 * 0.01 * (1 + 400 / 1000 * (5 - 1)) * (1 / 4 + 1) / 2 = 6.5. This equation can be though as attributing the
     // full period plus the multiplier growing over the full period * (1 / 4 + 1) / 2 which represents that for the first
-    // 200 seconds the pro-rate decision is 1 (i.e (1)/2) and for the second 200 seconds it is 1/4 (i.e (1/4)/2).
+    // 200 seconds the pro-rata decision is 1 (i.e (1)/2) and for the second 200 seconds it is 1/4 (i.e (1/4)/2).
     expect(await distributor.getOutstandingRewards(lpToken1.address, depositor1.address)).to.equal(toWei(6.5));
 
     // The depositor2 balance should simply be their prop-rate share of the distribution drawn over the 200 seconds as


### PR DESCRIPTION
# Problem
*N-07 Typographical errors*
The codebase contains the following typographical errors:
In AcceleratingDistributor.sol :
- On line 17 and line 89 pro-rate should be pro-rata .
- On line 126, after the end of the staking program ends is ungrammatical.
- On line 202, exists should be exits .
- On line 203, callers should be caller's .
- On line 228, the all information associated should be all the information associated .

Consider correcting these typos to improve the overall readability of the codebase.

# Solution:
All identified typos have been corrected.
