### PR TITLE
refactor(accelerating-distributor): Remove redundant _updateRewards from exit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The core logic of the contract enables stakers to lock up enabled LP tokens to e
 
 The contract is designed to hold multiple LP tokens with independent parameterization for each liquidity mining. This is done to enable the depositor to take advantage of multicall when depositing, claiming rewards and unstaking (i.e you can stake multiple tokens at once).
 
+The Distributor and Token contracts were audited by [OpenZeppelin](https://blog.openzeppelin.com/across-token-and-token-distributor-audit/).
+
 ## Build
 
 ```shell

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -229,6 +229,7 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      */
     function exit(address stakedToken) external onlyInitialized(stakedToken) {
         _updateReward(stakedToken, msg.sender);
+        require(stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance > 0, "Invalid amount");
         _unstake(stakedToken, stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance);
         _withdrawReward(stakedToken);
 

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -480,7 +480,6 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
             rewardsToSend,
             stakingTokens[stakedToken].lastUpdateTime,
             stakingTokens[stakedToken].rewardPerTokenStored,
-            userDeposit.rewardsOutstanding,
             userDeposit.rewardsAccumulatedPerToken
         );
     }

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -207,23 +207,9 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      * @param stakedToken The address of the token to withdraw.
      * @param amount The amount of the token to withdraw.
      */
-    function unstake(address stakedToken, uint256 amount) public nonReentrant onlyInitialized(stakedToken) {
+    function unstake(address stakedToken, uint256 amount) external nonReentrant onlyInitialized(stakedToken) {
         _updateReward(stakedToken, msg.sender);
-        UserDeposit storage userDeposit = stakingTokens[stakedToken].stakingBalances[msg.sender];
-
-        // Note: these will revert if underflow so you cant unstake more than your cumulativeBalance.
-        userDeposit.cumulativeBalance -= amount;
-        stakingTokens[stakedToken].cumulativeStaked -= amount;
-
-        IERC20(stakedToken).safeTransfer(msg.sender, amount);
-
-        emit Unstake(
-            stakedToken,
-            msg.sender,
-            amount,
-            userDeposit.cumulativeBalance,
-            stakingTokens[stakedToken].cumulativeStaked
-        );
+        _unstake(stakedToken, amount);
     }
 
     /**
@@ -231,26 +217,9 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      * @dev Calling this method will reset the caller's reward multiplier.
      * @param stakedToken The address of the token to get rewards for.
      */
-    function withdrawReward(address stakedToken) public nonReentrant onlyInitialized(stakedToken) {
+    function withdrawReward(address stakedToken) external nonReentrant onlyInitialized(stakedToken) {
         _updateReward(stakedToken, msg.sender);
-        UserDeposit storage userDeposit = stakingTokens[stakedToken].stakingBalances[msg.sender];
-
-        uint256 rewardsToSend = userDeposit.rewardsOutstanding;
-        if (rewardsToSend > 0) {
-            userDeposit.rewardsOutstanding = 0;
-            userDeposit.averageDepositTime = getCurrentTime();
-            rewardToken.safeTransfer(msg.sender, rewardsToSend);
-        }
-
-        emit RewardsWithdrawn(
-            stakedToken,
-            msg.sender,
-            rewardsToSend,
-            stakingTokens[stakedToken].lastUpdateTime,
-            stakingTokens[stakedToken].rewardPerTokenStored,
-            userDeposit.rewardsOutstanding,
-            userDeposit.rewardsAccumulatedPerToken
-        );
+        _withdrawReward(stakedToken);
     }
 
     /**
@@ -260,8 +229,8 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      */
     function exit(address stakedToken) external onlyInitialized(stakedToken) {
         _updateReward(stakedToken, msg.sender);
-        unstake(stakedToken, stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance);
-        withdrawReward(stakedToken);
+        _unstake(stakedToken, stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance);
+        _withdrawReward(stakedToken);
 
         emit Exit(stakedToken, msg.sender, stakingTokens[stakedToken].cumulativeStaked);
     }
@@ -418,6 +387,45 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
             averageDepositTime,
             userDeposit.cumulativeBalance,
             stakingTokens[stakedToken].cumulativeStaked
+        );
+    }
+
+    function _unstake(address stakedToken, uint256 amount) internal {
+        UserDeposit storage userDeposit = stakingTokens[stakedToken].stakingBalances[msg.sender];
+
+        // Note: these will revert if underflow so you cant unstake more than your cumulativeBalance.
+        userDeposit.cumulativeBalance -= amount;
+        stakingTokens[stakedToken].cumulativeStaked -= amount;
+
+        IERC20(stakedToken).safeTransfer(msg.sender, amount);
+
+        emit Unstake(
+            stakedToken,
+            msg.sender,
+            amount,
+            userDeposit.cumulativeBalance,
+            stakingTokens[stakedToken].cumulativeStaked
+        );
+    }
+
+    function _withdrawReward(address stakedToken) internal {
+        UserDeposit storage userDeposit = stakingTokens[stakedToken].stakingBalances[msg.sender];
+
+        uint256 rewardsToSend = userDeposit.rewardsOutstanding;
+        if (rewardsToSend > 0) {
+            userDeposit.rewardsOutstanding = 0;
+            userDeposit.averageDepositTime = getCurrentTime();
+            rewardToken.safeTransfer(msg.sender, rewardsToSend);
+        }
+
+        emit RewardsWithdrawn(
+            stakedToken,
+            msg.sender,
+            rewardsToSend,
+            stakingTokens[stakedToken].lastUpdateTime,
+            stakingTokens[stakedToken].rewardPerTokenStored,
+            userDeposit.rewardsOutstanding,
+            userDeposit.rewardsAccumulatedPerToken
         );
     }
 }

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -266,8 +266,8 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      * @param stakedToken The address of the token to get rewards for.
      */
     function exit(address stakedToken) external onlyInitialized(stakedToken) {
-        _updateReward(stakedToken, msg.sender);
         require(stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance > 0, "Invalid amount");
+        _updateReward(stakedToken, msg.sender);
         _unstake(stakedToken, stakingTokens[stakedToken].stakingBalances[msg.sender].cumulativeBalance);
         _withdrawReward(stakedToken);
 
@@ -446,6 +446,7 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
         );
     }
 
+    // Decreases user's staked balance by `amount` and returns to user.
     function _unstake(address stakedToken, uint256 amount) internal {
         UserDeposit storage userDeposit = stakingTokens[stakedToken].stakingBalances[msg.sender];
 


### PR DESCRIPTION
Refactors withdrawRewards() and unstake() to call internal methods _withdrawRewards() and _unstake() so that exit() only calls _updateRewards() once