### PR TITLE
fix: [L01] Dangerous maximum values for reward calculations

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -158,7 +158,7 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
         require(stakedToken != address(rewardToken), "Staked token is reward token");
         require(maxMultiplier <= 1e24, "maxMultiplier too large"); // 1_000_000x multiplier.
         require(maxMultiplier >= 1e18, "maxMultiplier less than 1e18");
-        require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier <= 0");
+        require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier is 0");
         require(baseEmissionRate <= 1e24, "baseEmissionRate too large"); // 1 million tokens per second.
 
         StakingToken storage stakingToken = stakingTokens[stakedToken];

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -127,7 +127,7 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
         // benefit to removing this additional flexibility. If set < 1e18, then user's rewards outstanding will
         // decrease over time. Incentives for stakers would look different if `maxMultiplier` were set < 1e18
         require(stakedToken != address(rewardToken), "Staked token is reward token");
-        require(maxMultiplier <= 10e18, "maxMultiplier too large"); // 1000% realistic upper bound.
+        require(maxMultiplier <= 1e24, "maxMultiplier too large"); // 1_000_000x multiplier.
         require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier <= 0");
         require(baseEmissionRate <= 1e24, "baseEmissionRate too large"); // 1 million ACX per second.
 

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -129,7 +129,7 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
         require(stakedToken != address(rewardToken), "Staked token is reward token");
         require(maxMultiplier <= 1e24, "maxMultiplier too large"); // 1_000_000x multiplier.
         require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier <= 0");
-        require(baseEmissionRate <= 1e24, "baseEmissionRate too large"); // 1 million ACX per second.
+        require(baseEmissionRate <= 1e24, "baseEmissionRate too large"); // 1 million tokens per second.
 
         StakingToken storage stakingToken = stakingTokens[stakedToken];
 

--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -127,9 +127,9 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
         // benefit to removing this additional flexibility. If set < 1e18, then user's rewards outstanding will
         // decrease over time. Incentives for stakers would look different if `maxMultiplier` were set < 1e18
         require(stakedToken != address(rewardToken), "Staked token is reward token");
-        require(maxMultiplier < 1e36, "maxMultiplier can not be set too large");
-        require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier must be greater than 0");
-        require(baseEmissionRate < 1e27, "baseEmissionRate can not be set too large");
+        require(maxMultiplier <= 10e18, "maxMultiplier too large"); // 1000% realistic upper bound.
+        require(secondsToMaxMultiplier > 0, "secondsToMaxMultiplier <= 0");
+        require(baseEmissionRate <= 1e24, "baseEmissionRate too large"); // 1 million ACX per second.
 
         StakingToken storage stakingToken = stakingTokens[stakedToken];
 

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -121,10 +121,10 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
         toWei(toWei(1)),
         secondsToMaxMultiplier
       )
-    ).to.be.revertedWith("maxMultiplier can not be set too large");
+    ).to.be.revertedWith("maxMultiplier too large");
     await expect(
       distributor.configureStakingToken(lpToken1.address, true, baseEmissionRate, maxMultiplier, 0)
-    ).to.be.revertedWith("secondsToMaxMultiplier must be greater than 0");
+    ).to.be.revertedWith("secondsToMaxMultiplier <= 0");
     await expect(
       distributor.configureStakingToken(
         lpToken1.address,
@@ -133,7 +133,7 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
         maxMultiplier,
         secondsToMaxMultiplier
       )
-    ).to.be.revertedWith("baseEmissionRate can not be set too large");
+    ).to.be.revertedWith("baseEmissionRate too large");
   });
 
   it("Non owner cant execute admin functions", async function () {

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -127,7 +127,7 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
 
     await expect(
       distributor.configureStakingToken(lpToken1.address, true, baseEmissionRate, maxMultiplier, 0)
-    ).to.be.revertedWith("secondsToMaxMultiplier <= 0");
+    ).to.be.revertedWith("secondsToMaxMultiplier is 0");
 
     await expect(
       distributor.configureStakingToken(

--- a/test/AcceleratingDistributor.Admin.ts
+++ b/test/AcceleratingDistributor.Admin.ts
@@ -118,7 +118,7 @@ describe("AcceleratingDistributor: Admin Functions", async function () {
         lpToken1.address,
         true,
         baseEmissionRate,
-        toWei(toWei(1)),
+        toWei(10000000),
         secondsToMaxMultiplier
       )
     ).to.be.revertedWith("maxMultiplier too large");


### PR DESCRIPTION
# L-01 Dangerous maximum values for reward

## Description: 
The configureStakingToken function in the AcceleratingDistributor contract
contains hard-coded upper limits that ensure maxMultiplier is set below 1e36 and
baseEmissionRate is set below 1e27 . However, these limits are many orders of magnitude
above the intended operating parameters for the contract.
According to the Across documentation for rewards locking, the value of maxMultiplier
should never exceed 3e18 for the initial reward locking program; 1e36 is many orders of
magnitude larger.

The rewards locking documentation also states that the initial token supply for rewards is
75,000,000 ACX tokens. This equates to 7.5e25 wei, but the upper limit of 1e27 on
baseEmissionRate allows a token emission rate per second that is two orders of magnitude
higher than the total supply to be emitted.

Through an accidental or malicious administrative action, maxMultiplier and/or
baseEmissionRate could be set to values that rapidly deplete the rewards pool, allowing
some users to claim excessively large reward payouts until the error is discovered and
corrected.

Consider setting the upper limits for maxMultiplier and baseEmissionRate much
closer to the expected maximum operating values. For example, setting upper limits no more
than 1 order of magnitude above the maximum expected values reduces risk while still
allowing some flexibility to change the terms of the rewards program in the future.

## Fix
We set a 1000% upper limit for `maxMultiplier` (e.g. 10e18) and a 1 million per second upper limit for `baseEmissionRate` (e.g. 1e6 * 1e18 = 1e24).

﻿Signed-off-by: nicholaspai <npai.nyc@gmail.com>
