### PR TITLE
improve: [N-01] Remove redundant event parameter

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -94,7 +94,6 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
         uint256 rewardsToSend,
         uint256 tokenLastUpdateTime,
         uint256 tokenRewardPerTokenStored,
-        uint256 userRewardsOutstanding,
         uint256 userRewardsPaidPerToken
     );
     event Exit(address indexed token, address indexed user, uint256 tokenCumulativeStaked);
@@ -248,7 +247,6 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
             rewardsToSend,
             stakingTokens[stakedToken].lastUpdateTime,
             stakingTokens[stakedToken].rewardPerTokenStored,
-            userDeposit.rewardsOutstanding,
             userDeposit.rewardsAccumulatedPerToken
         );
     }

--- a/test/AcceleratingDistributor.Events.ts
+++ b/test/AcceleratingDistributor.Events.ts
@@ -107,7 +107,7 @@ describe("AcceleratingDistributor: Events", async function () {
     const currentTime = await distributor.getCurrentTime();
     await expect(distributor.connect(depositor1).withdrawReward(lpToken1.address))
       .to.emit(distributor, "RewardsWithdrawn")
-      .withArgs(lpToken1.address, depositor1.address, toWei(3.6), currentTime, toWei(0.2), 0, toWei(0.2));
+      .withArgs(lpToken1.address, depositor1.address, toWei(3.6), currentTime, toWei(0.2), toWei(0.2));
   });
   it("Exit", async function () {
     // Exit calls unstake and getRewards. We've tested these events already so nothing needed on those. Just test Exit.


### PR DESCRIPTION
The userRewardsOutstanding value is always set to 0 when emitted, so remove it.