### PR TITLE
fix: [N-02] Misleading documentation

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -162,8 +162,8 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
     function recoverToken(address token) external onlyOwner {
         // If the token is an enabled staking token then we want to preform a skim action where we send back any extra
         // tokens that are not accounted for in the cumulativeStaked variable. This lets the owner recover extra tokens
-        // sent to the contract that were not explicitly staked. if the token is not enabled for staking then we simply
-        // send back the full amount of tokens that the contract has.
+        // sent to the contract that were not explicitly staked. If the token has not been initialized for staking then
+        // we simply send back the full amount of tokens that the contract has.
         uint256 amount = IERC20(token).balanceOf(address(this));
         if (stakingTokens[token].lastUpdateTime != 0) amount -= stakingTokens[token].cumulativeStaked;
         require(amount > 0, "Can't recover 0 tokens");


### PR DESCRIPTION
Per an OZ finding, the recoverToken() function specifically checks for whether the token has been initialized; not whether it is currently enabled via staking configuration.

Note that an additional comment regarding the maxMultiplier used in tests was provided. This is currently _not_ implemented, because the current maxMultiplier of 3 represents current Across LP staking policy, rather than the technical constraints of the underlying contract.