### PR TITLE
fix: Reinstate docstrings

### DIFF
--- a/contracts/AcceleratingDistributor.sol
+++ b/contracts/AcceleratingDistributor.sol
@@ -126,6 +126,11 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      *            CONSTRUCTOR             *
      **************************************/
 
+    /**
+     * @notice AcceleratingDistributor constructor.
+     * @dev The reward token is immutable once the contact has been deployed.
+     * @param _rewardToken Contract address of token to be used for staking rewards.
+     */
     constructor(address _rewardToken) {
         rewardToken = IERC20(_rewardToken);
     }
@@ -322,6 +327,10 @@ contract AcceleratingDistributor is ReentrancyGuard, Ownable, Multicall {
      *           VIEW FUNCTIONS           *
      **************************************/
 
+    /**
+     * @notice Returns the current block timestamp.
+     * @return uint256 Current block timestamp.
+     */
     function getCurrentTime() public view virtual returns (uint256) {
         return block.timestamp; // solhint-disable-line not-rely-on-time
     }


### PR DESCRIPTION
These were erroneously removed in the following commit:

  be635c47f7860bc8759aac3e6152e4c6da7221d3.